### PR TITLE
Reorganize install section

### DIFF
--- a/datalad_dataset_addition_procedure.md
+++ b/datalad_dataset_addition_procedure.md
@@ -10,7 +10,9 @@
 
 ## Setup - Installing required software (assumes working on a Linux machine):
 
-### Install on a Linux machine
+Note: as of August 14 2019, this command installs git annex v 7.20190730, which works with CONP datasets. Earlier versions of git-annex, including the default version available with Ubuntu 18.04, may not, because some CONP datasets are hosted on ftp servers and git-annex did not support ftp for some time in 2018/2019.
+
+### Install on a Linux machine with root access
 
 Installation in this order is strongly recommended.
 
@@ -36,8 +38,6 @@ First install the neurodebian package repository:
 Then install the version of git-annex included in this repository:
 
 ```sudo apt-get install git-annex-standalone```
-
-As of August 14 2019, this command installs git annex v 7.20190730, which works with CONP datasets. Earlier versions of git-annex, including the default version available with Ubuntu 18.04, may not, because some CONP datasets are hosted on ftp servers and git-annex did not support ftp for some time in 2018/2019.
 
 The version of git-annex installed can be verified with:
 
@@ -70,8 +70,6 @@ sh Miniconda3-4.7.12.1-Linux-x86_64.sh
 2. git-annex:
 
 ```conda install -c conda-forge git-annex```
-
-As of March 11 2020, this command installs git annex v 8.20200309, which works with CONP datasets. Versions early than 7.20190730 of git-annex, including the default version available with Ubuntu 18.04, may not, because some CONP datasets are hosted on ftp servers and git-annex did not support ftp for some time in 2018/2019.
 
 The version of git-annex installed can be verified with:
 

--- a/datalad_dataset_addition_procedure.md
+++ b/datalad_dataset_addition_procedure.md
@@ -54,33 +54,9 @@ Alternatively, for people working with Python, run the following in your virtual
 
 For more information on how to install DataLad on a Linux system, please visit [Install DataLad section of the DataLad's handbook](http://handbook.datalad.org/en/latest/intro/installation.html#linux-neuro-debian-ubuntu-and-similar-systems).
 
-### Install on a Linux machine with no root access
+### Install on a Linux machines with no root access (e.g. HPC systems)
 
-
-Installation in this order is strongly recommended.
-
-1. conda:
-
-```
-wget https://repo.anaconda.com/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh
-sh Miniconda3-4.7.12.1-Linux-x86_64.sh
-```
-
-
-2. git-annex:
-
-```conda install -c conda-forge git-annex```
-
-The version of git-annex installed can be verified with:
-
-```git annex version```
-
-
-3. datalad:
-
-```pip install datalad```
-
-For more information on how to install DataLad on a Linux system, please visit [Install DataLad section of the DataLad's handbook](http://handbook.datalad.org/en/latest/intro/installation.html#linux-machines-with-no-root-access-e-g-hpc-systems).
+Please visit the Install DataLad section of the [DataLad's handbook](http://handbook.datalad.org/en/latest/index.html) and follow the instruction to [Install DataLad on linux-machines with no root access](http://handbook.datalad.org/en/latest/intro/installation.html#linux-machines-with-no-root-access-e-g-hpc-systems).
 
 ### Install on Mac OS X
 


### PR DESCRIPTION
In this PR, the paragraph about git-annex and datalad versions was moved up as it implies to install on any system (linux or mac). The instruction for the conda install have been removed as they are identical to the ones mentioned in the DataLad Handbook and a link to the instructions is already present.