### PR TITLE
Add proper link to the DATS GUI editor and quick fixes on the current documentation displayed on the portal

### DIFF
--- a/Documentation_displayed_on_the_portal/Share_Dataset_Instruction_Page.md
+++ b/Documentation_displayed_on_the_portal/Share_Dataset_Instruction_Page.md
@@ -11,7 +11,7 @@ Below, we describe four different methods for adding your data to the CONP Porta
 
 - A `README.md` file: The content of this file will be displayed in the portal page describing your dataset. It is in Markdown format, to which there are many guides but [here is one quick cheatsheet]( https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet).
 
-- A `DATS.json` file: as described in [the main documentation page](https://github.com/CONP-PCNO/conp-documentation/blob/master/CONP_DATS_fields.md). We provide a [DATS GUI editor]() ***(#TODO: ADD LINK TO EDITOR)*** for easy creation of this file. Note: the content of the `DATS.json` file will used to populate various fields describing your dataset on its Portal page.
+- A `DATS.json` file: as described in [the main documentation page](https://github.com/CONP-PCNO/conp-documentation/blob/master/CONP_DATS_fields.md). We provide a [DATS GUI editor](https://portal.conp.ca/dats-editor) for easy creation of this file. Note: the content of the `DATS.json` file will used to populate various fields describing your dataset on its Portal page.
 
 #### <a name="optional"></a> *Optional files in the root directory*
 

--- a/datalad_dataset_addition_procedure.md
+++ b/datalad_dataset_addition_procedure.md
@@ -1,4 +1,4 @@
-[Upload a tool/pipeline](#pipeline) | [Upload a dataset](#dataset)
+[Upload a tool/pipeline](#pipeline) | [Upload a dataset](#dataset) | [DATS Editor](https://portal.conp.ca/dats-editor)
 
 # <a name="pipeline"></a> I. Tool/pipeline addition procedure
 
@@ -106,7 +106,7 @@ All commands presented in the following sections should be run from ```projects/
 All datasets must include a `README.md` in the root directory.
 Adding metadata about your dataset is required. 
 
-All datasets must include a `DATS.json` metadata file in the root directory as described in [the main documentation page](https://github.com/CONP-PCNO/conp-documentation/blob/master/CONP_main_data_documentation.htm).
+All datasets must include a `DATS.json` metadata file in the root directory as described in [the main documentation page](https://github.com/CONP-PCNO/conp-documentation/blob/master/CONP_DATS_fields.md). For convenience, a [DATS Editor](https://portal.conp.ca/dats-editor) has been created on the portal to facilitate the creation of the DATS.json file.
 
 (It is not necessary to manually create these files when using Zenodo as the CONP Zenodo crawler automatically generates them.)
 


### PR DESCRIPTION
This PR fixes a bug in the current documentation displayed on the portal and adds the proper link to the DATS editor in the documentation.