### PR TITLE
Minor updates to CONP_dataset_checks.md

### DIFF
--- a/Developers-Notes/CONP_dataset_checks.md
+++ b/Developers-Notes/CONP_dataset_checks.md
@@ -42,14 +42,14 @@ To carry out this procedure:
 
 4) Remove the connection to the original fork of the submodule using the [git submodule deletion procedure](https://github.com/CONP-PCNO/conp-documentation/blob/master/Developers-Notes/Datalad/fix_git_submodule_problem.md).
 
-5) Save the current state of your fork of conp-dataset using ```datalad save``` and ```datalad publish --to origin``` as usual.
+5) Save the current state of your fork of conp-dataset using ```datalad save``` and ```datalad push --to origin``` as usual.
 
 6) Reinstall the conpdatasets fork of the submodule:
 
 ```
-git submodule add https://github.com/conpdatasets/<submodule>
+git submodule add https://github.com/conpdatasets/<submodule> projects/<submodule>
 ```
 
-7) Save reinstalled state of your fork of conp-dataset using ```datalad save``` and ```datalad publish --to origin```.
+7) Save reinstalled state of your fork of conp-dataset using ```datalad save``` and ```datalad push --to origin```.
 
 8) Submit a PR from your fork to CONP-PCNO/conp-dataset.

--- a/Developers-Notes/CONP_dataset_checks.md
+++ b/Developers-Notes/CONP_dataset_checks.md
@@ -50,6 +50,8 @@ To carry out this procedure:
 git submodule add https://github.com/conpdatasets/<submodule> projects/<submodule>
 ```
 
-7) Save reinstalled state of your fork of conp-dataset using ```datalad save``` and ```datalad push --to origin```.
+7) Confirm correct formatting in the updated ```.gitmodules``` file, which may mean adding a trailing ```.git``` extension to the repository address.
 
-8) Submit a PR from your fork to CONP-PCNO/conp-dataset.
+8) Save reinstalled state of your fork of conp-dataset using ```datalad save``` and ```datalad push --to origin```.
+
+9) Submit a PR from your fork to CONP-PCNO/conp-dataset.

--- a/Documentation_displayed_on_the_portal/Share_Instruction_Page.md
+++ b/Documentation_displayed_on_the_portal/Share_Instruction_Page.md
@@ -156,8 +156,10 @@ datalad save -m "<a constructive message describing the state of the dataset>"
 Ensure that all changes have been saved in DataLad (`datalad save -m "<message>"`). Then, from the DataLad directory, publish the DataLad dataset to GitHub:
 
  ```
- datalad publish --to github
+ datalad push --to github
  ```
+
+[ <b>NB</b>: In versions of datalad before 0.13, this functionality used ```datalad publish```.  There are some differences between these two commands but they are not relevant to this operation. ]
   
 ##### <a name="dataset_test"></a> 5) Testing the new dataset before adding it to the [CONP-PCNO/conp-dataset](https://github.com/CONP-PCNO/conp-dataset) DataLad super dataset
 
@@ -215,7 +217,7 @@ To add the newly created dataset to the list of CONP datasets present in the Dat
 
 	```
 	datalad save -m '<message>'
-	datalad publish --to origin
+	datalad push --to origin
 	```
 
 - Send a pull request (PR) from your fork's `master` branch to the `master` branch of `https://github.com/CONP-PCNO/conp-dataset`. You should see 2 file changes in the PR:


### PR DESCRIPTION
This update corrects and clarifies a couple of points in the procedure for updating dataset links from the dataset providers' github repositories to forks stored in `conpdatasets`.