### PR TITLE
Updating data share documentation to include note about changing default branch.

### DIFF
--- a/Documentation_displayed_on_the_portal/Share_Instruction_Page.md
+++ b/Documentation_displayed_on_the_portal/Share_Instruction_Page.md
@@ -165,7 +165,16 @@ Ensure that all changes have been saved in DataLad (`datalad save -m "<message>"
   
 ##### <a name="dataset_test"></a> 5) Testing the new dataset before adding it to the [CONP-PCNO/conp-dataset](https://github.com/CONP-PCNO/conp-dataset) DataLad super dataset
 
+
+
 Test that the dataset published on the new GitHub repository can be correctly downloaded:
+
+- Check that the default branch on the dataset is set to `master`:
+
+1) Open the repository on Github
+2) Click on the Settings tab (rightmost in the menu below the repository title)
+3) Click on Branches in the menu on the left of the page. The Default branch setting is at the top of the page this retrieves.
+4) If the default branch is set to `git-annex`, change it to `master`.
 
 - Do a clean install of the new dataset GitHub repository on a different directory:
 


### PR DESCRIPTION
Recently something in the interaction of Datalad and Github has changed so that when a Github sibling is created using Datalad the default branch can be set to `git-annex`.  If this happens, adding that dataset as a submodule of `conp-dataset` according to our existing procedure gives a non-functional link.  Changing the default branch for a dataset on Github is straightforward, and this update adds a warning and instructions on how to do this to `Share_Instructions_Page.md`.