### PR TITLE
Update documentation on share page for github default branch name change.

### DIFF
--- a/Documentation_displayed_on_the_portal/Share_Instruction_Page.md
+++ b/Documentation_displayed_on_the_portal/Share_Instruction_Page.md
@@ -239,9 +239,11 @@ To add the newly created dataset to the list of CONP datasets present in the Dat
 			url = https://github.com/<username>/<new_dataset_name>.git
 			branch = main
   		```
-   		*note: ensure that there is an empty line at the end of the `.gitmodules` file otherwise it will not pass the format-checking tests of your PR.
  		
-The last line may need to be added manually.  This is now required for compatibility with [github renaming the default branch] (https://github.com/github/renaming).
+The last line will need to be added manually.  This is now required for compatibility with [github renaming the default branch](https://github.com/github/renaming).
+   		
+*note: ensure that there is an empty line at the end of the `.gitmodules` file otherwise it will not pass the format-checking tests of your PR.
+
 
   - a link to the latest commit of the <new_dataset_name> GitHub repository
 

--- a/Documentation_displayed_on_the_portal/Share_Instruction_Page.md
+++ b/Documentation_displayed_on_the_portal/Share_Instruction_Page.md
@@ -237,17 +237,11 @@ To add the newly created dataset to the list of CONP datasets present in the Dat
 		[submodule "projects/<new_dataset_name>"]
 			path = projects/<new_dataset_name>
 			url = https://github.com/<username>/<new_dataset_name>.git
-  		```
-   		*note: ensure that there is an empty line at the end of the `.gitmodules` file otherwise it will not pass the format-checking tests of your PR.
- 		*note: it is now necessary to manually edit the `.gitmodules` file to add one additional line:
-  		```
-		[submodule "projects/<new_dataset_name>"]
-			path = projects/<new_dataset_name>
-			url = https://github.com/<username>/<new_dataset_name>.git
 			branch = main
   		```
-		This is required for compatibility with [github renaming the default branch] (https://github.com/github/renaming).
-
+   		*note: ensure that there is an empty line at the end of the `.gitmodules` file otherwise it will not pass the format-checking tests of your PR.
+ 		
+The last line may need to be added manually.  This is now required for compatibility with [github renaming the default branch] (https://github.com/github/renaming).
 
   - a link to the latest commit of the <new_dataset_name> GitHub repository
 

--- a/Documentation_displayed_on_the_portal/Share_Instruction_Page.md
+++ b/Documentation_displayed_on_the_portal/Share_Instruction_Page.md
@@ -239,7 +239,16 @@ To add the newly created dataset to the list of CONP datasets present in the Dat
 			url = https://github.com/<username>/<new_dataset_name>.git
   		```
    		*note: ensure that there is an empty line at the end of the `.gitmodules` file otherwise it will not pass the format-checking tests of your PR.
-   
+ 		*note: it is now necessary to manually edit the `.gitmodules` file to add one additional line:
+  		```
+		[submodule "projects/<new_dataset_name>"]
+			path = projects/<new_dataset_name>
+			url = https://github.com/<username>/<new_dataset_name>.git
+			branch = main
+  		```
+		This is required for compatibility with [github renaming the default branch] (https://github.com/github/renaming).
+
+
   - a link to the latest commit of the <new_dataset_name> GitHub repository
 
 ---


### PR DESCRIPTION
This PR adds instructions to manually add `branch = main` to the `.gitmodules` file when adding a new dataset, in order to fix issues transferring data between servers arising from Github renaming the default branch from `master` to `main` (see https://github.com/github/renaming).